### PR TITLE
increase WaitForStackLambdaFunction timeout from 5m to 10m.  

### DIFF
--- a/Reliability/300_Testing_for_Resiliency_of_EC2_RDS_and_S3/Code/CloudFormation/lambda_functions_for_deploy.json
+++ b/Reliability/300_Testing_for_Resiliency_of_EC2_RDS_and_S3/Code/CloudFormation/lambda_functions_for_deploy.json
@@ -207,7 +207,7 @@
         "MemorySize" :  "128",
         "Role" : { "Fn::GetAtt" : [ "WaitForStackLambdaRole", "Arn" ] },
         "Runtime" : "python3.6",
-        "Timeout" : "300"
+        "Timeout" : "600"
       }
     },
 

--- a/Reliability/300_Testing_for_Resiliency_of_EC2_RDS_and_S3/Code/CloudFormation/lambda_functions_for_deploy_two_regions.json
+++ b/Reliability/300_Testing_for_Resiliency_of_EC2_RDS_and_S3/Code/CloudFormation/lambda_functions_for_deploy_two_regions.json
@@ -206,7 +206,7 @@
         "MemorySize" :  "128",
         "Role" : { "Fn::GetAtt" : [ "WaitForStackLambdaRole", "Arn" ] },
         "Runtime" : "python3.6",
-        "Timeout" : "300"
+        "Timeout" : "600"
       }
     },
 

--- a/Reliability/300_Testing_for_Resiliency_of_EC2_RDS_and_S3/Code/CloudFormation/lambda_functions_for_deploy_two_regions_w_o_defaults.json
+++ b/Reliability/300_Testing_for_Resiliency_of_EC2_RDS_and_S3/Code/CloudFormation/lambda_functions_for_deploy_two_regions_w_o_defaults.json
@@ -199,7 +199,7 @@
         "MemorySize" :  "128",
         "Role" : { "Fn::GetAtt" : [ "WaitForStackLambdaRole", "Arn" ] },
         "Runtime" : "python3.6",
-        "Timeout" : "300"
+        "Timeout" : "600"
       }
     },
 


### PR DESCRIPTION
increase WaitForStackLambdaFunction timeout from 5m to 10m.  This may be temporary, pending https://github.com/setheliot/aws-well-architected-labs/issues/20

*Issue #, if available:*
https://github.com/setheliot/aws-well-architected-labs/issues/37

*Description of changes:*
- This will prevent students from having to redrive the deployment

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
