### PR TITLE
WebServersforResiliencyTesting -> WebServersForResiliencyTesting

### DIFF
--- a/Reliability/300_Testing_for_Resiliency_of_EC2_RDS_and_S3/Code/Python/DMSLambda/deploy_dms_lambda.py
+++ b/Reliability/300_Testing_for_Resiliency_of_EC2_RDS_and_S3/Code/Python/DMSLambda/deploy_dms_lambda.py
@@ -288,7 +288,7 @@ if __name__ == "__main__":
             "status": "CREATE_COMPLETE"
         },
         "web": {
-            "stackname": "WebServersforResiliencyTesting",
+            "stackname": "WebServersForResiliencyTesting",
             "status": "CREATE_COMPLETE"
         },
         "rr": {

--- a/Reliability/300_Testing_for_Resiliency_of_EC2_RDS_and_S3/Code/Python/ReadReplicaLambda/deploy_read_replica_lambda.py
+++ b/Reliability/300_Testing_for_Resiliency_of_EC2_RDS_and_S3/Code/Python/ReadReplicaLambda/deploy_read_replica_lambda.py
@@ -262,7 +262,7 @@ if __name__ == "__main__":
             'status': 'CREATE_COMPLETE'
         },
         'web': {
-            'stackname': 'WebServersforResiliencyTesting',
+            'stackname': 'WebServersForResiliencyTesting',
             'status': 'CREATE_COMPLETE'
         }
     }

--- a/Reliability/300_Testing_for_Resiliency_of_EC2_RDS_and_S3/Code/Python/WebAppLambda/deploy_web_lambda.py
+++ b/Reliability/300_Testing_for_Resiliency_of_EC2_RDS_and_S3/Code/Python/WebAppLambda/deploy_web_lambda.py
@@ -26,7 +26,7 @@ import json
 
 LOG_LEVELS = {'CRITICAL': 50, 'ERROR': 40, 'WARNING': 30, 'INFO': 20, 'DEBUG': 10}
 
-stackname = 'WebServersforResiliencyTesting'
+stackname = 'WebServersForResiliencyTesting'
 
 AWS_REGION = 'us-east-2'
 
@@ -77,7 +77,7 @@ def process_global_vars():
     logger.info("Processing variables from environment.")
     try:
         global stackname
-        stackname = 'WebServersforResiliencyTesting'
+        stackname = 'WebServersForResiliencyTesting'
     except SystemExit:
         sys.exit(1)
     except Exception:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Correct naming of WebServersForResiliencyTesting (a bit nit-picky, but why not?)
This is code-only -- I also updated the Lab Guide to the proper spelling in branch https://github.com/setheliot/aws-well-architected-labs/tree/Rel300_docs_seliot

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
