### PR TITLE
change WebServerAutoscalingGroup_minsize from 2 back to 3

### DIFF
--- a/Reliability/300_Testing_for_Resiliency_of_EC2_RDS_and_S3/Code/CloudFormation/web_server_autoscaling.json
+++ b/Reliability/300_Testing_for_Resiliency_of_EC2_RDS_and_S3/Code/CloudFormation/web_server_autoscaling.json
@@ -199,7 +199,7 @@
       "Type" : "AWS::AutoScaling::AutoScalingGroup",
       "Properties" : {
         "AvailabilityZones" : {"Ref" : "AvailabilityZones"},
-        "MinSize" : "2",
+        "MinSize" : "3",
         "MaxSize" : "3",
         "HealthCheckType" : "ELB",
         "HealthCheckGracePeriod" : "60",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* change WebServerAutoscalingGroup_minsize from 2 back to 3
  * @adhorn intended to return this to 3 as part of https://github.com/setheliot/aws-well-architected-labs/pull/19


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
